### PR TITLE
add github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to reproduce
+<!-- Please describe in detail how the bug can be reproduced -->
+
+### Environment
+<!-- Specify browser version and OS. If you know also include on what branch you experienced this bug or write the commit hash that has introduced the bug -->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. Add checklist item(s) and remove examples not applicable -->
+- [ ] <!-- Issue specific criteria -->
+- [ ] Tests verifying the fix are added
+
+## Screenshots 
+<!-- If applicable, add screenshots/videos to help explain your problem -->
+
+## Additional context
+<!-- Add any other context about the problem here, e.g. if only applicable on certain browsers or devices -->

--- a/.github/ISSUE_TEMPLATE/EPIC.md
+++ b/.github/ISSUE_TEMPLATE/EPIC.md
@@ -1,0 +1,23 @@
+---
+name: Epic
+about: a big piece of new functionality
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Please describe the epic
+<!-- Please fill in the brackets -->
+As a [type of user], I want [an action] so that [a benefit/a value].
+
+## Break down into smaller parts 
+<!-- Which parts of the new functionality can you already identify? Add them to the list -->
+- [ ] Write an item here
+
+## Additional context
+<!-- Add any other context or screenshots about the new functionality -->
+
+## Open questions
+<!-- What is still unclear about the new functionality? Add questions and whom to ask -->
+- [ ] First question (ask [person])

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Please describe the feature
+<!-- Please fill in the brackets -->
+As a [type of user], I want [an action] so that [a benefit/a value].
+
+## Detailed description 
+<!-- What should be done for the issue to be considered completed. Add checklist item(s) and remove examples not applicable -->
+- [ ] Write an item here
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!-- Remove sections from this template that are not used -->
+## Related issue(s) and PR(s)
+
+This PR closes [issue number] and relates to [issue or PR number].
+
+<!-- Include below a description of the changes proposed in the pull request -->
+
+## Type of change
+
+<!-- Please delete options that are not relevant -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Other
+
+## List of changes made
+
+<!-- Specify what changes have been made and why -->
+
+## Screenshot of the fix
+
+<!-- Attach screenshot if relevant -->
+
+## Testing
+
+<!-- Please delete options that are not relevant -->
+
+- A certain branch in other repos is needed
+- A rebuild is needed due to new dependencies
+- Requires new configuration settings
+- Instructions on how to test
+
+## Further comments
+
+<!-- Specify questions or related information -->
+
+## Definition of Done checklist
+
+- [ ] I have made an effort making the commit history understandable
+- [ ] I have performed a self-review of my own code and commented any hard-to-understand areas
+- [ ] Existing tests are passing and I wrote unit tests for new functionality
+- [ ] My changes generate no new warnings
+- [ ] Make sure the layout and text follow design sketches, if there are any
+- [ ] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue:
+- [ ] **Code Review Completed:**
+  - The code has been reviewed by at least one team member other than its author (adhering to the four-eyes principle).
+  - Considerations: PR reviews, presentations to co-workers, pair/mob programming sessions.
+  
+- [ ] **Documentation Updated (if applicable):**
+  - Relevant documentation is current.
+  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
+  
+- [ ] **Follow-up Backlog Items Created (if applicable):**
+  - Necessary follow-up tasks have been identified and added to the backlog.
+  - Considerations: next iteration tasks, performance enhancements, visual improvements, refactoring needs, addressing technical debt.


### PR DESCRIPTION
# Related issue
This PR closes #15 .

# List of changes

- add `.github` folder
- add issue template for epic
- add issue template for feature request
- add issue template for bug report
- add PR template

# Testing

- [ ] Read through the templates and make sure they make sense

# Additional comment
These templates are the exact same that we just set up for the birdringing project.