### PR TITLE
feat: Use session context to implicitly rollback/commit

### DIFF
--- a/backend/src/psc_atlas/session.py
+++ b/backend/src/psc_atlas/session.py
@@ -12,10 +12,9 @@ def get_session():
     """Provide a transactional scope around a series of operations."""
     session = SessionLocal()
     try:
-        yield session
-        session.commit()
+        with session.begin():
+            yield session
     except Exception as e:
-        session.rollback()
         logger.exception("Session rollback because of exception")
         raise
     finally:

--- a/backend/src/psc_atlas/session.py
+++ b/backend/src/psc_atlas/session.py
@@ -10,12 +10,5 @@ logger = logging.getLogger(__name__)
 @contextmanager
 def get_session():
     """Provide a transactional scope around a series of operations."""
-    session = SessionLocal()
-    try:
-        with session.begin():
-            yield session
-    except Exception as e:
-        logger.exception("Session rolled back due to an exception: %s", e)
-        raise
-    finally:
-        session.close()
+    with SessionLocal() as session, session.begin():
+        yield session

--- a/backend/src/psc_atlas/session.py
+++ b/backend/src/psc_atlas/session.py
@@ -15,7 +15,7 @@ def get_session():
         with session.begin():
             yield session
     except Exception as e:
-        logger.exception("Session rollback because of exception")
+        logger.exception("Session rolled back due to an exception: %s", e)
         raise
     finally:
         session.close()


### PR DESCRIPTION
A minimal PR for an update to the database session management, prompted by a review by @pdmnyberg.

The commit removes the explicit calls to `session.commit()` and `session.rollback()` and instead uses `session.begin()` as a context manager.

Benefits:

- More explicit transaction boundaries.
- Automatic commit/rollback when entering/exiting the context.
- Follows SQLAlchemy's recommended pattern for transaction management.
- Cleaner separation of concerns.



---

Co-pilot summary:

This pull request refactors the session management logic in the `get_session` context manager to simplify transaction handling and resource cleanup.

Database session management:

* Refactored the `get_session` context manager in `session.py` to use a `with` statement for both session creation and transaction scope, removing manual commit, rollback, and close operations for improved readability and reliability.