### PR TITLE
Fix explore data link in sidebar 

### DIFF
--- a/frontend/src/app/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/app/components/Sidebar/Sidebar.tsx
@@ -3,102 +3,70 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import styles from "./sidebar.module.scss";
-import Contact from "@/app/components/Contact/Contact";
 
 type SidebarProps = {
-    contact: React.ReactNode;
+  contact: React.ReactNode;
 };
 
 export default function Sidebar({ contact }: SidebarProps) {
-    const [open, setOpen] = useState(true);
-    const [underMenuOpen, setUnderMenuOpen] = useState(false);
+  const [open, setOpen] = useState(true);
 
-    useEffect(() => {
-        if (typeof window !== "undefined" && window.innerWidth < 768) {
-            setOpen(false);
-        }
-    }, []);
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.innerWidth < 768) {
+      setOpen(false);
+    }
+  }, []);
 
-    useEffect(() => {
-        const handler = () => setOpen((prev) => !prev);
-        window.addEventListener("psc:toggleSidebar", handler);
-        return () => window.removeEventListener("psc:toggleSidebar", handler);
-    }, []);
+  useEffect(() => {
+    const handler = () => setOpen((prev) => !prev);
+    window.addEventListener("psc:toggleSidebar", handler);
+    return () => window.removeEventListener("psc:toggleSidebar", handler);
+  }, []);
 
-    return (
-        <aside
-            className={`${styles.sidebar} ${open ? styles.open : styles.closed}`}
+  return (
+    <aside
+      className={`${styles.sidebar} ${open ? styles.open : styles.closed}`}
+    >
+      <div className={styles.inner}>
+        <button
+          type="button"
+          className={`btn btn-link p-0 d-md-none ${styles["mobile-close"]}`}
+          onClick={() => setOpen(false)}
+          aria-label="Close menu"
         >
-            <div className={styles.inner}>
-                <button
-                    type="button"
-                    className={`btn btn-link p-0 d-md-none ${styles["mobile-close"]}`}
-                    onClick={() => setOpen(false)}
-                    aria-label="Close menu"
-                >
-                    <i className="bi bi-x fs-3 text-primary"></i>
-                </button>
-                <h2 className="h5 fw-bold mb-3">Menu</h2>
-                <div className={styles["red-line"]}></div>
-                <ul className="list-unstyled mb-4">
-                    <li className={styles.item}>
-                        <Link href="/" className={styles["sidebar-link"]}>
-                            Home
-                        </Link>
-                    </li>
-
-                    <li className={styles.item}>
-                        <button
-                            type="button"
-                            className={`${styles.summary} btn btn-link p-0 w-100 text-start d-flex justify-content-between align-items-center`}
-                            onClick={() => setUnderMenuOpen((p) => !p)}
-                            aria-expanded={underMenuOpen}
-                        >
-                            <span>Data exploration</span>
-                            <i
-                                className={`bi ms-2 ${
-                                    underMenuOpen ? "bi-chevron-up" : "bi-chevron-down"
-                                }`}
-                            ></i>
-                        </button>
-                        {underMenuOpen && (
-                            <ul className="list-unstyled ms-3 mt-2">
-                                <li>
-                                    <Link href="#" className={styles["sub-link"]}>
-                                        Protein 7k, plasma
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link href="#" className={styles["sub-link"]}>
-                                        metabolite, plasma
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link href="#" className={styles["sub-link"]}>
-                                        miRNA, plasma
-                                    </Link>
-                                </li>
-                            </ul>
-                        )}
-                    </li>
-                    <li className={styles.item}>
-                        <Link href="/the-project" className={styles["sidebar-link"]}>
-                            The Project
-                        </Link>
-                    </li>
-                    <li className={styles.item}>
-                        <Link href="/publications" className={styles["sidebar-link"]}>
-                            Publications
-                        </Link>
-                    </li>
-                    <li className={styles.item}>
-                        <Link href="#" className={styles["sidebar-link"]}>
-                            Request data for research
-                        </Link>
-                    </li>
-                </ul>
-                {contact}
-            </div>
-        </aside>
-    );
+          <i className="bi bi-x fs-3 text-primary"></i>
+        </button>
+        <h2 className="h5 fw-bold mb-3">Menu</h2>
+        <div className={styles["red-line"]}></div>
+        <ul className="list-unstyled mb-4">
+          <li className={styles.item}>
+            <Link href="/" className={styles["sidebar-link"]}>
+              Home
+            </Link>
+          </li>
+          <li className={styles.item}>
+            <Link href="/explore-data" className={styles["sidebar-link"]}>
+              Explore Data
+            </Link>
+          </li>
+          <li className={styles.item}>
+            <Link href="/the-project" className={styles["sidebar-link"]}>
+              The Project
+            </Link>
+          </li>
+          <li className={styles.item}>
+            <Link href="/publications" className={styles["sidebar-link"]}>
+              Publications
+            </Link>
+          </li>
+          <li className={styles.item}>
+            <Link href="#" className={styles["sidebar-link"]}>
+              Request data for research
+            </Link>
+          </li>
+        </ul>
+        {contact}
+      </div>
+    </aside>
+  );
 }

--- a/frontend/src/app/explore-data/page.tsx
+++ b/frontend/src/app/explore-data/page.tsx
@@ -9,6 +9,10 @@ type Condition = {
   values: string[];
 };
 
+type TypesResponse = {
+  types: string[];
+};
+
 type ConditionResponse = {
   conditions: Condition[];
 };
@@ -64,6 +68,8 @@ const calculateViolinData = (
 };
 
 const ExploreData: React.FC = () => {
+  const [datasets, setDatasets] = useState<string[]>([]);
+  const [selectedDataset, setSelectedDataset] = useState<string>();
   const [conditions, setConditions] = useState<Condition[]>([]);
   const [variables, setVariables] = useState<string[]>([]);
   const [selectedXaxis, setSelectedXaxis] = useState<Condition>();
@@ -80,13 +86,26 @@ const ExploreData: React.FC = () => {
     violinColors: ["#f67878", "#3d4449", "#F7C59F"],
   });
 
-  // should come from the URL in the future depending on the user's
-  // menu choice (metabolite / protein/ miRNA). Should also become a type.
-  const dataset = "proteins";
+  const getDatasets = async () => {
+    try {
+      const response = await fetch(`/api/v1/sample/types`);
+      if (!response.ok) {
+        throw new Error("Couldn't receive types.");
+      }
+      const fetchedDatasets: TypesResponse = await response.json();
+      setDatasets(fetchedDatasets.types);
+    } catch (error) {
+      console.log("An error occured: ", error);
+      setDatasets([]);
+    }
+    return;
+  };
 
   const getConditions = async () => {
     try {
-      const response = await fetch(`/api/v1/sample/conditions?type=${dataset}`);
+      const response = await fetch(
+        `/api/v1/sample/conditions?type=${selectedDataset}`
+      );
       if (!response.ok) {
         throw new Error("Couldn't receive conditions.");
       }
@@ -101,7 +120,9 @@ const ExploreData: React.FC = () => {
 
   const getVariables = async () => {
     try {
-      const response = await fetch(`/api/v1/sample/variables?type=${dataset}`);
+      const response = await fetch(
+        `/api/v1/sample/variables?type=${selectedDataset}`
+      );
       if (!response.ok) {
         throw new Error("Couldn't receive variables.");
       }
@@ -114,9 +135,25 @@ const ExploreData: React.FC = () => {
   };
 
   useEffect(() => {
+    getDatasets();
+  }, []);
+
+  useEffect(() => {
     getConditions();
     getVariables();
-  }, []);
+  }, [selectedDataset]);
+
+  const handleSelectDataset = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedXaxis(undefined);
+    setSelectedLegend(undefined);
+    setXAxisValues([]);
+    setLegendValues([]);
+    setSelectedVariable(undefined);
+    setData([]);
+    setSelectedDataset(
+      datasets.find((dataset) => dataset === event.target.value)
+    );
+  };
 
   const handleSelectXaxis = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setXAxisValues([]);
@@ -172,7 +209,7 @@ const ExploreData: React.FC = () => {
     setPlotInfo(currentPlotInfo);
     try {
       const response = await fetch(
-        `/api/v1/sample/measurements?type=${dataset}&variable=${selectedVariable}`,
+        `/api/v1/sample/measurements?type=${selectedDataset}&variable=${selectedVariable}`,
         {
           method: "POST",
           headers: {
@@ -232,175 +269,200 @@ const ExploreData: React.FC = () => {
   return (
     <>
       <section>
-        <div>
-          <form className="d-flex flex-column mb-5">
-            <h5>Choose your x-axis variable</h5>
-            <label htmlFor="xAxis">Select condition</label>
-            <select
-              id="xAxis"
-              value={selectedXaxis ? selectedXaxis.name : ""}
-              onChange={handleSelectXaxis}
-              className="form-select mb-3"
-            >
-              <option value="" disabled>
-                No condition selected
-              </option>
-              {conditions &&
-                conditions.map((condition) => (
-                  <option
-                    key={"x-" + condition.name}
-                    value={condition.name}
-                    disabled={
-                      selectedLegend && selectedLegend.name === condition.name
-                    }
-                  >
-                    {condition.name}
-                  </option>
-                ))}
-            </select>
-
-            {selectedXaxis && (
-              <fieldset className="mb-3">
-                <legend className="fs-6">
-                  Which values should be included?
-                </legend>
-                {selectedXaxis.values
-                  .filter((value) => value !== "NA")
-                  .map((value) => (
-                    <div key={value} className="form-check">
-                      <input
-                        type="checkbox"
-                        id={`${selectedXaxis.name}-${value}`}
-                        value={value}
-                        checked={xAxisValues.includes(value)}
-                        onChange={handleXAxisValues}
-                        className="form-check-input"
-                      />
-                      <label htmlFor={`${selectedXaxis.name}-${value}`}>
-                        {value}
-                      </label>
-                    </div>
-                  ))}
-              </fieldset>
-            )}
-
-            <h5>Choose your legend variable</h5>
-            <label htmlFor="legend">Select condition</label>
-            <select
-              id="legend"
-              value={selectedLegend ? selectedLegend.name : ""}
-              onChange={handleSelectLegend}
-              className="form-select mb-3"
-            >
-              <option value="">No condition selected</option>
-              {conditions &&
-                conditions.map((condition) => (
-                  <option
-                    key={condition.name}
-                    value={condition.name}
-                    disabled={
-                      selectedXaxis && selectedXaxis.name === condition.name
-                    }
-                  >
-                    {condition.name}
-                  </option>
-                ))}
-            </select>
-
-            {selectedLegend && (
-              <fieldset className="mb-3">
-                <legend className="fs-6">
-                  Which values should be included?
-                </legend>
-                {selectedLegend.values
-                  .filter((value) => value !== "NA")
-                  .map((value) => (
-                    <div key={value} className="form-check">
-                      <input
-                        type="checkbox"
-                        id={`${selectedLegend.name}-${value}`}
-                        value={value}
-                        checked={legendValues.includes(value)}
-                        onChange={handleLegendValues}
-                        className="form-check-input"
-                      />
-                      <label htmlFor={`${selectedLegend.name}-${value}`}>
-                        {value}
-                      </label>
-                    </div>
-                  ))}
-              </fieldset>
-            )}
-
-            <h5>Select your {dataset}</h5>
-            <label htmlFor="variable">Select {dataset}</label>
-            <select
-              id="variable"
-              value={selectedVariable ? selectedVariable : ""}
-              onChange={handleSelectVariable}
-              className="form-select"
-            >
-              <option value="" disabled></option>
-              {variables &&
-                variables.map((variable) => (
-                  <option key={variable} value={variable}>
-                    {variable}
-                  </option>
-                ))}
-            </select>
-          </form>
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={() => getData()}
-            disabled={
-              !selectedXaxis || xAxisValues.length == 0 || !selectedVariable
-            }
+        <form className="d-flex flex-column mb-5">
+          <h5>Which dataset do you want to explore?</h5>
+          <label>Select dataset</label>
+          <select
+            id="datasets"
+            value={selectedDataset ? selectedDataset : ""}
+            onChange={handleSelectDataset}
+            className="form-select mb-3"
           >
-            Create plot
-          </button>
-        </div>
+            <option>No dataset selected</option>
+            {datasets &&
+              datasets.map((dataset) => (
+                <option key={dataset} value={dataset}>
+                  {dataset}
+                </option>
+              ))}
+          </select>
+        </form>
       </section>
-      <section>
-        {data && data.length > 0 && (
-          <Plot
-            data={[
-              {
-                type: "violin",
-                x: xA,
-                y: yA,
-                legendgroup: "groupA",
-                name: `${plotInfo.legendVar} - ${plotInfo.legendValues[0]}`,
-                box: { visible: true },
-                line: { color: plotInfo.violinColors[0] },
-                meanline: { visible: true },
-                showlegend: true,
-                visible: yA.length == 0 ? "legendonly" : true,
-                points: "all",
-                jitter: 0.2,
-                pointpos: -1.3,
-              },
-              {
-                type: "violin",
-                x: xB,
-                y: yB,
-                legendgroup: "groupB",
-                name: `${plotInfo.legendVar} - ${plotInfo.legendValues[1]}`,
-                box: { visible: true },
-                line: { color: plotInfo.violinColors[1] },
-                meanline: { visible: true },
-                showlegend: true,
-                visible: yB.length == 0 ? "legendonly" : true,
-                points: "all",
-                jitter: 0.2,
-                pointpos: -1.3,
-              },
-            ]}
-            layout={layout}
-            onClick={() => console.log("clicked")}
-          />
-        )}
-      </section>
+      {selectedDataset && (
+        <>
+          <section>
+            <div>
+              <form className="d-flex flex-column mb-5">
+                <h5>Choose your x-axis variable</h5>
+                <label htmlFor="xAxis">Select condition</label>
+                <select
+                  id="xAxis"
+                  value={selectedXaxis ? selectedXaxis.name : ""}
+                  onChange={handleSelectXaxis}
+                  className="form-select mb-3"
+                >
+                  <option value="" disabled>
+                    No condition selected
+                  </option>
+                  {conditions &&
+                    conditions.map((condition) => (
+                      <option
+                        key={"x-" + condition.name}
+                        value={condition.name}
+                        disabled={
+                          selectedLegend &&
+                          selectedLegend.name === condition.name
+                        }
+                      >
+                        {condition.name}
+                      </option>
+                    ))}
+                </select>
+
+                {selectedXaxis && (
+                  <fieldset className="mb-3">
+                    <legend className="fs-6">
+                      Which values should be included?
+                    </legend>
+                    {selectedXaxis.values
+                      .filter((value) => value !== "NA")
+                      .map((value) => (
+                        <div key={value} className="form-check">
+                          <input
+                            type="checkbox"
+                            id={`${selectedXaxis.name}-${value}`}
+                            value={value}
+                            checked={xAxisValues.includes(value)}
+                            onChange={handleXAxisValues}
+                            className="form-check-input"
+                          />
+                          <label htmlFor={`${selectedXaxis.name}-${value}`}>
+                            {value}
+                          </label>
+                        </div>
+                      ))}
+                  </fieldset>
+                )}
+
+                <h5>Choose your legend variable</h5>
+                <label htmlFor="legend">Select condition</label>
+                <select
+                  id="legend"
+                  value={selectedLegend ? selectedLegend.name : ""}
+                  onChange={handleSelectLegend}
+                  className="form-select mb-3"
+                >
+                  <option value="">No condition selected</option>
+                  {conditions &&
+                    conditions.map((condition) => (
+                      <option
+                        key={condition.name}
+                        value={condition.name}
+                        disabled={
+                          selectedXaxis && selectedXaxis.name === condition.name
+                        }
+                      >
+                        {condition.name}
+                      </option>
+                    ))}
+                </select>
+
+                {selectedLegend && (
+                  <fieldset className="mb-3">
+                    <legend className="fs-6">
+                      Which values should be included?
+                    </legend>
+                    {selectedLegend.values
+                      .filter((value) => value !== "NA")
+                      .map((value) => (
+                        <div key={value} className="form-check">
+                          <input
+                            type="checkbox"
+                            id={`${selectedLegend.name}-${value}`}
+                            value={value}
+                            checked={legendValues.includes(value)}
+                            onChange={handleLegendValues}
+                            className="form-check-input"
+                          />
+                          <label htmlFor={`${selectedLegend.name}-${value}`}>
+                            {value}
+                          </label>
+                        </div>
+                      ))}
+                  </fieldset>
+                )}
+
+                <h5>Select your {selectedDataset}</h5>
+                <label htmlFor="variable">Select {selectedDataset}</label>
+                <select
+                  id="variable"
+                  value={selectedVariable ? selectedVariable : ""}
+                  onChange={handleSelectVariable}
+                  className="form-select"
+                >
+                  <option value="" disabled></option>
+                  {variables &&
+                    variables.map((variable) => (
+                      <option key={variable} value={variable}>
+                        {variable}
+                      </option>
+                    ))}
+                </select>
+              </form>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => getData()}
+                disabled={
+                  !selectedXaxis || xAxisValues.length == 0 || !selectedVariable
+                }
+              >
+                Create plot
+              </button>
+            </div>
+          </section>
+          <section>
+            {data && data.length > 0 && (
+              <Plot
+                data={[
+                  {
+                    type: "violin",
+                    x: xA,
+                    y: yA,
+                    legendgroup: "groupA",
+                    name: `${plotInfo.legendVar} - ${plotInfo.legendValues[0]}`,
+                    box: { visible: true },
+                    line: { color: plotInfo.violinColors[0] },
+                    meanline: { visible: true },
+                    showlegend: true,
+                    visible: yA.length == 0 ? "legendonly" : true,
+                    points: "all",
+                    jitter: 0.2,
+                    pointpos: -1.3,
+                  },
+                  {
+                    type: "violin",
+                    x: xB,
+                    y: yB,
+                    legendgroup: "groupB",
+                    name: `${plotInfo.legendVar} - ${plotInfo.legendValues[1]}`,
+                    box: { visible: true },
+                    line: { color: plotInfo.violinColors[1] },
+                    meanline: { visible: true },
+                    showlegend: true,
+                    visible: yB.length == 0 ? "legendonly" : true,
+                    points: "all",
+                    jitter: 0.2,
+                    pointpos: -1.3,
+                  },
+                ]}
+                layout={layout}
+                onClick={() => console.log("clicked")}
+              />
+            )}
+          </section>
+        </>
+      )}
     </>
   );
 };

--- a/frontend/src/app/explore-data/page.tsx
+++ b/frontend/src/app/explore-data/page.tsx
@@ -156,17 +156,19 @@ const ExploreData: React.FC = () => {
   };
 
   const handleSelectXaxis = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setXAxisValues([]);
-    setSelectedXaxis(
-      conditions.find((condition) => condition.name === event.target.value)
+    const condition = conditions.find(
+      (condition) => condition.name === event.target.value
     );
+    setSelectedXaxis(condition);
+    condition && setXAxisValues(condition.values);
   };
 
   const handleSelectLegend = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setLegendValues([]);
-    setSelectedLegend(
-      conditions.find((condition) => condition.name === event.target.value)
+    const condition = conditions.find(
+      (condition) => condition.name === event.target.value
     );
+    setSelectedLegend(condition);
+    condition && setLegendValues(condition.values);
   };
 
   const handleSelectVariable = (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,40 +6,7 @@ const Home = () => {
   return (
     <>
       <section>
-        <h2>PSC Atlas</h2>
-        <p>Hello world!</p>
-        <button type="button" className="btn btn-primary">
-          Button test
-        </button>
-        <button type="button" className="btn btn-outline-primary">
-          Outline test
-        </button>
-        <div className="form-check">
-          <input
-            className="form-check-input p-2"
-            type="checkbox"
-            value=""
-            id="flexCheckDefault"
-          />
-          <label className="form-check-label" htmlFor="flexCheckDefault">
-            Default checkbox
-          </label>
-        </div>
-        <select
-          className="form-select"
-          defaultValue="0"
-          aria-label="Default select example"
-        >
-          <option value="0">Open this select menu</option>
-          <option value="1">One</option>
-          <option value="2">Two</option>
-          <option value="3">Three</option>
-        </select>
-      </section>
-      <section>
-        <nav>
-          <Link href="/explore-data">Explore Data</Link>
-        </nav>
+        <h2>Welcome to the SUPRIM Atlas!</h2>
       </section>
     </>
   );


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #60 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## List of changes made
- the submenu for the explorable datasets in the sidebar was removed and replaced by a simple navigation link. 
- the selection of datasets was moved from the sidebar (where it was supposed to be implemented) to the explore-data page

The reason for these changes is that the dataset selection in the sidebar would have required dynamic routes to `explore-data/[dataset]`. This turned out to be complicated (if not impossible) to implement within the server-side rendered project that we have today. The solution in this PR was much easier and quicker to implement and as we are currently out of hours for the project, I chose to solve it this way.

- Dummy content from the home page was removed
- The values for legend and x-axis are now checked by default. This has nothing to do with the rest of the PR but it was something that Martin would have liked to get done and it was a quick fix.

## Screenshot of the fix

<img width="1637" height="760" alt="image" src="https://github.com/user-attachments/assets/f3d5cf9d-c75a-4a2f-afb7-8614b206bb12" />

## Testing

<!-- Please delete options that are not relevant -->

- Make sure that you can reach the /explore-data page from the sidebar
- on explore-data, make sure that you can select a dataset. Selecting a dataset should make the rest of the page (except the plot) visible
- changing your dataset selection should reset all other choices you have made on the page and remove any existing plot
- Going back to "No dataset selected", the rest of the page content should be hidden again
- Whenever you select a condition for x-axis or legend, the appearing checkboxes should be checked by default

## Further comments
Sorry for the many changes due to formatting in the Sidebar component! If this was a bigger project, I would ask for some formatter / linter, but given the size of the project, I just hope it won't happen again.

The changes in the JSX part of the explore-data page file look big but this is because nearly all of the page content now is conditionally rendered depending on the selected dataset.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [ ] Make sure the layout and text follow design sketches, if there are any
- [ ] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue:
- [ ] **Code Review Completed:**
  - The code has been reviewed by at least one team member other than its author (adhering to the four-eyes principle).
  - Considerations: PR reviews, presentations to co-workers, pair/mob programming sessions.
  
- [ ] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
  
- [ ] **Follow-up Backlog Items Created (if applicable):**
  - Necessary follow-up tasks have been identified and added to the backlog.
  - Considerations: next iteration tasks, performance enhancements, visual improvements, refactoring needs, addressing technical debt.
